### PR TITLE
Unlink project from a specific boto3 version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ package_dir =
 packages = find:
 python_requires = >=2.7
 install_requires =
-    boto3 == 1.17.112
+    boto3 >= 1.17.112
 
 [options.extras_require]
 tests = pytest < 7; moto[sqs] < 3


### PR DESCRIPTION
1.17.112 is already 11 months old and behind several minor versions.